### PR TITLE
Fix edge case for absurd MOFs

### DIFF
--- a/src/eval/mof_generation.py
+++ b/src/eval/mof_generation.py
@@ -282,8 +282,8 @@ def array_dict_to_structure(
         # returns an absurd MOF
         frac_coords = np.zeros_like(x["frac_coords"])
         atom_types = np.zeros_like(x["atom_types"])
-        lengths = 100 * np.ones_like(x["lengths"]).squeeze().tolist()
-        angles = 90 * np.ones_like(x["angles"]).squeeze().tolist()
+        lengths = (100 * np.ones_like(x["lengths"])).squeeze().tolist()
+        angles = (90 * np.ones_like(x["angles"])).squeeze().tolist()
         sample_idx = x["sample_idx"]
 
         struct = Structure(

--- a/src/eval/mof_generation.py
+++ b/src/eval/mof_generation.py
@@ -293,6 +293,6 @@ def array_dict_to_structure(
             coords_are_cartesian=False,
         )
         struct.properties["sample_idx"] = sample_idx
-        struct.properties["struct_valid"] = False
+        struct.properties["valid"] = False
 
     return struct

--- a/src/eval/mof_generation.py
+++ b/src/eval/mof_generation.py
@@ -281,7 +281,7 @@ def array_dict_to_structure(
     except:
         # returns an absurd MOF
         frac_coords = np.zeros_like(x["frac_coords"])
-        atom_types = np.zeros_like(x["atom_types"])
+        atom_types = np.ones_like(x["atom_types"])
         lengths = (100 * np.ones_like(x["lengths"])).squeeze().tolist()
         angles = (90 * np.ones_like(x["angles"])).squeeze().tolist()
         sample_idx = x["sample_idx"]

--- a/src/eval/mof_reconstruction.py
+++ b/src/eval/mof_reconstruction.py
@@ -280,8 +280,8 @@ def array_dict_to_structure(
         # returns an absurd MOF
         frac_coords = np.zeros_like(x["frac_coords"])
         atom_types = np.zeros_like(x["atom_types"])
-        lengths = 100 * np.ones_like(x["lengths"]).squeeze().tolist()
-        angles = 90 * np.ones_like(x["angles"]).squeeze().tolist()
+        lengths = (100 * np.ones_like(x["lengths"])).squeeze().tolist()
+        angles = (90 * np.ones_like(x["angles"])).squeeze().tolist()
         sample_idx = x["sample_idx"]
 
         struct = Structure(

--- a/src/eval/mof_reconstruction.py
+++ b/src/eval/mof_reconstruction.py
@@ -279,7 +279,7 @@ def array_dict_to_structure(
     except:
         # returns an absurd MOF
         frac_coords = np.zeros_like(x["frac_coords"])
-        atom_types = np.zeros_like(x["atom_types"])
+        atom_types = np.ones_like(x["atom_types"])
         lengths = (100 * np.ones_like(x["lengths"])).squeeze().tolist()
         angles = (90 * np.ones_like(x["angles"])).squeeze().tolist()
         sample_idx = x["sample_idx"]

--- a/src/models/ldm_module.py
+++ b/src/models/ldm_module.py
@@ -379,7 +379,7 @@ class LatentDiffusionLitModule(LightningModule):
                     random_translation = (
                         torch.normal(
                             torch.abs(batch.lengths.mean(dim=0)),
-                            torch.abs(batch.lengths.std(dim=0)) + 1e-8,
+                            torch.abs(batch.lengths.std(dim=0).nan_to_num(1e-8)),
                         )
                         / 2
                     )

--- a/src/models/vae_module.py
+++ b/src/models/vae_module.py
@@ -402,7 +402,7 @@ class VariationalAutoencoderLitModule(LightningModule):
                     random_translation = (
                         torch.normal(
                             torch.abs(batch.lengths.mean(dim=0)),
-                            torch.abs(batch.lengths.std(dim=0)) + 1e-8,
+                            torch.abs(batch.lengths.std(dim=0).nan_to_num(1e-8)),
                         )
                         / 2
                     )


### PR DESCRIPTION
1. Fixes an edge case for absurd MOFs where default `lengths` and `angles` would accidentally be list-expanded instead of being multiplied by a constant value.
2. Fixes an edge case for absurd MOFs where the default `atom_types` would accidentally be set to `0`, which is not a valid atom type index.
3. Fixes an edge case for absurd MOFs where the default `valid` status would be populated as `struct_valid` instead.
4. Lastly, fixes a NaN-causing error that occurs when calling `std(dim=0)` on `batch.lengths` when `batch_size=1`.